### PR TITLE
update travis's dist to Xenial.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-dist: trusty
 language: ruby
 cache: bundler
 rvm:
@@ -8,13 +7,6 @@ rvm:
   - 2.5.8
 addons:
   chrome: stable
-  apt:
-    packages:
-      - chromium-chromedriver
 before_install:
   - export TZ=Asia/Tokyo
   - gem install bundler -v 2.1.4
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3

--- a/spec/capybara_helper.rb
+++ b/spec/capybara_helper.rb
@@ -4,17 +4,16 @@ require 'capybara/minitest'
 require 'webdrivers/chromedriver'
 
 Capybara.register_driver :headless_chrome do |app|
-  driver = Capybara::Selenium::Driver.new(
+  options = Selenium::WebDriver::Chrome::Options.new
+  options.add_argument('headless')
+  options.add_argument('--disable-gpu')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
+  Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    desired_capabilities: Selenium::WebDriver::Remote::Capabilities.chrome(
-      login_prefs: { browser: 'ALL' },
-      chrome_options: {
-        args: %w[headless disable-gpu window-size=1900,1200 lang=ja no-sandbox disable-dev-shm-usage],
-      }
-    )
+    options: options
   )
-  driver
 end
 
 Capybara.server = :webrick


### PR DESCRIPTION
I updated dist to Xenial because trusty can only install the old chrome version and the test fails, so I updated dist to Xenial.

ref: https://travis-ci.community/t/travisci-chrome-version-has-regressed-back-to-v62/8603

It seems that the setting of ChromeDriver of Capybarah was wrong.

``` ruby
     Selenium::WebDriver::Error::UnknownError:
       unknown error: Chrome failed to start: crashed.
         (unknown error: DevToolsActivePort file doesn't exist)
         (The process started from chrome location /usr/bin/google-chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
```

Using Selenium::WebDriver::Remote::Capabilities was not a good idea, so I've modified it to use Selenium::WebDriver::Chrome::Options to configure it :thinking: